### PR TITLE
feat: add generic type to Generator trait

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,11 +1,13 @@
 mod constants;
 mod number_generator;
 
+use std::fmt::Display;
+
 pub use number_generator::NumberGenerator;
 
-pub trait Generator {
+pub trait Generator<T: Display> {
     fn supply_line_start(&self) -> &str;
     fn supply_line_end(&self) -> &str;
-    fn supply_element(&mut self) -> &str;
+    fn supply_element(&mut self) -> T;
     fn supply_col_delimiter(&self) -> &str;
 }

--- a/src/generator/number_generator.rs
+++ b/src/generator/number_generator.rs
@@ -10,7 +10,6 @@ use super::constants::{EMPTY_STRING, NEW_LINE};
 use super::Generator;
 
 pub struct NumberGenerator {
-    buffer: String,
     rng: SmallRng,
     uniform: Uniform<i128>,
     column_delimiter: String,
@@ -19,7 +18,6 @@ pub struct NumberGenerator {
 impl NumberGenerator {
     pub fn new(range: Range<i128>, column_delimiter: &str) -> Self {
         NumberGenerator {
-            buffer: String::new(),
             rng: rand::rngs::SmallRng::from_entropy(),
             column_delimiter: column_delimiter.to_owned(),
             uniform: Uniform::from(range),
@@ -27,7 +25,7 @@ impl NumberGenerator {
     }
 }
 
-impl Generator for NumberGenerator {
+impl Generator<i128> for NumberGenerator {
     fn supply_line_start(&self) -> &str {
         EMPTY_STRING
     }
@@ -36,11 +34,8 @@ impl Generator for NumberGenerator {
         NEW_LINE
     }
 
-    fn supply_element(&mut self) -> &str {
-        let element = self.uniform.sample(&mut self.rng);
-        self.buffer = element.to_string();
-
-        &self.buffer
+    fn supply_element(&mut self) -> i128 {
+        self.uniform.sample(&mut self.rng)
     }
 
     fn supply_col_delimiter(&self) -> &str {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,11 +1,12 @@
+use std::fmt::Display;
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use crate::generator::Generator;
 
-pub fn write_matrix_into_file(
-    generator: &mut impl Generator,
+pub fn write_matrix_into_file<T: Display>(
+    generator: &mut impl Generator<T>,
     filename: &str,
     row_count: u128,
     col_count: u128,
@@ -20,8 +21,8 @@ pub fn write_matrix_into_file(
     write_matrix(generator, &mut file, row_count, col_count)
 }
 
-pub fn write_matrix(
-    generator: &mut impl Generator,
+pub fn write_matrix<T: Display>(
+    generator: &mut impl Generator<T>,
     writable: &mut impl Write,
     row_count: u128,
     col_count: u128,


### PR DESCRIPTION
By adding a generic type to the Generator trait, it was possible to avoid calling to_string() method of the supplied element, which resulted in much better matrix write speed.